### PR TITLE
[SYS-2605] Fix json serialization double conversion may overflow int64_t

### DIFF
--- a/folly/Conv.h
+++ b/folly/Conv.h
@@ -744,7 +744,11 @@ estimateSpaceNeeded(Src value) {
 
 namespace detail {
 constexpr int kConvMaxDecimalInShortestLow = -6;
-constexpr int kConvMaxDecimalInShortestHigh = 21;
+// int64_t range: [-9223372036854775808, 9223372036854775807]
+// The max value is 19 digits in decimal. To prevent double numbers without
+// fraction got converted to an integer overflowing int64_t, we must let it use
+// scientific representation when there are >=19 digits before decimal point.
+constexpr int kConvMaxDecimalInShortestHigh = 18;
 } // namespace detail
 
 /** Wrapper around DoubleToStringConverter **/


### PR DESCRIPTION
as title, we must set `kConvMaxDecimalInShortestHigh` lower or equal to 18

examples of how this arg is used in `double-conversion`
https://github.com/google/double-conversion/blob/master/double-conversion/double-to-string.h#L116-L118

test added in rs https://github.com/rockset/rs/pull/12908