### PR TITLE
Use allocateOverAligned to allocate memory when using ConcurrentHashMap

### DIFF
--- a/folly/concurrency/ConcurrentHashMap.h
+++ b/folly/concurrency/ConcurrentHashMap.h
@@ -155,6 +155,7 @@ class ConcurrentHashMap {
   using EnableHeterogeneousFind = std::enable_if_t<
       detail::EligibleForHeterogeneousFind<KeyType, HashFn, KeyEqual, K>::value,
       T>;
+  using SegAlloc = typename std::allocator_traits<Allocator>::template rebind_alloc<SegmentT>;
 
   float load_factor_ = SegmentT::kDefaultLoadFactor;
 
@@ -228,7 +229,7 @@ class ConcurrentHashMap {
       auto seg = segments_[i].load(std::memory_order_relaxed);
       if (seg) {
         seg->~SegmentT();
-        Allocator().deallocate((uint8_t*)seg, sizeof(SegmentT));
+        deallocateOverAligned(SegAlloc(), seg, 1);
       }
       segments_[i].store(
           o.segments_[i].load(std::memory_order_relaxed),
@@ -248,7 +249,7 @@ class ConcurrentHashMap {
       auto seg = segments_[i].load(std::memory_order_relaxed);
       if (seg) {
         seg->~SegmentT();
-        Allocator().deallocate((uint8_t*)seg, sizeof(SegmentT));
+        deallocateOverAligned(SegAlloc(), seg, 1);
       }
     }
     cohort_shutdown_cleanup();
@@ -648,13 +649,13 @@ class ConcurrentHashMap {
     SegmentT* seg = segments_[i].load(std::memory_order_acquire);
     if (!seg) {
       auto b = ensureCohort();
-      SegmentT* newseg = (SegmentT*)Allocator().allocate(sizeof(SegmentT));
+      SegmentT* newseg = allocateOverAligned(SegAlloc(), 1);
       newseg = new (newseg)
           SegmentT(size_ >> ShardBits, load_factor_, max_size_ >> ShardBits, b);
       if (!segments_[i].compare_exchange_strong(seg, newseg)) {
         // seg is updated with new value, delete ours.
         newseg->~SegmentT();
-        Allocator().deallocate((uint8_t*)newseg, sizeof(SegmentT));
+        deallocateOverAligned(SegAlloc(), newseg, 1);
       } else {
         seg = newseg;
       }


### PR DESCRIPTION
Use aligned memory allocation and de allocation for `ConcurrentHashMapSegment` in `ConcurrentHashMap` to resolve the UBSAN failures. 

Test:
https://buildkite.com/rockset/c-plus-plus-sanitizers/builds/6206. 